### PR TITLE
add preview font-family config, extend Ruby kanji range.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -134,7 +134,7 @@ function markUpHtml( myhtml ){
 
     taggedHTML = taggedHTML.replace(/<!-- (.+?) -->/g, '<span class="comment"><span class="commentbody">$1</span></span>');
     taggedHTML = taggedHTML.replace(/｜([^｜\n]+?)《([^《]+?)》/g, '<ruby>$1<rt>$2</rt></ruby>');
-    taggedHTML = taggedHTML.replace(/([一-龠]+?)《(.+?)》/g, '<ruby>$1<rt>$2</rt></ruby>');
+    taggedHTML = taggedHTML.replace(/([一-鿏々-〇]+?)《(.+?)》/g, '<ruby>$1<rt>$2</rt></ruby>');
     taggedHTML = taggedHTML.replace(/(.+?)［＃「\1」に傍点］/g, '<em class="side-dot">$1</em>');
     return taggedHTML;
 }
@@ -144,6 +144,7 @@ function getWebviewContent(userstylesheet) {
     //configuration 読み込み
     const config = vscode.workspace.getConfiguration('Novel');
         let lineheightrate = 1.75;
+        let fontfamily = config.get('preview.font-family');
         let fontsize = config.get('preview.fontsize');
         let numfontsize = /(\d+)(\D+)/.exec(fontsize)[1];
         let unitoffontsize = /(\d+)(\D+)/.exec(fontsize)[2];
@@ -416,7 +417,8 @@ function getWebviewContent(userstylesheet) {
   @media screen{
       body {
             writing-mode: vertical-rl;
-            font-family:"ヒラギノ明朝 ProN W3", "HiraMinProN-W3", serif, sans-serif;
+            font-family: ${fontfamily};
+            //font-family:"ヒラギノ明朝 ProN W3", "HiraMinProN-W3", serif, sans-serif;
             height: ${pageheight};
             overflow-y:hidden;
             padding:0;
@@ -431,7 +433,8 @@ function getWebviewContent(userstylesheet) {
   
         p {
             height: ${pageheight};
-            font-family:"ヒラギノ明朝 ProN W3", "HiraMinProN-W3", serif, sans-serif;
+            font-family: ${fontfamily};
+            //font-family:"ヒラギノ明朝 ProN W3", "HiraMinProN-W3", serif, sans-serif;
             line-height: ${lineheightrate};
             font-size: ${fontsize};
             margin:0 0 0 0;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
         "configuration": {
             "title": "縦書きプレビュー設定",
             "properties": {
+                "Novel.preview.font-family":{
+                    "type": "string",
+                    "default": "\"MS Gothic\"",
+                    "description":"プレビュー用のフォント名を入力してください。 \ne.g. \"UD Digi Kyokasho NK-R\",\"ヒラギノ明朝 ProN W3\", \"HiraMinProN-W3\", serif, sans-serif;"
+                },
                 "Novel.preview.fontsize": {
                     "type": "string",
                     "default": "14pt",

--- a/syntaxes/novel.tmGrammar.json
+++ b/syntaxes/novel.tmGrammar.json
@@ -15,7 +15,7 @@
         ]
       },
       "rubymother": {
-        "match": "((｜.+?)|([\u4E00-\u9FFF]+))(?=《.+?》)",
+        "match": "((｜.+?)|([\u4E00-\u9FFF\u3005-\u3007]+))(?=《.+?》)",
         "name": "keyword"
       },
       "aozora-motherword": {


### PR DESCRIPTION
以下の機能を追加しました。

1. プレビュー用フォントファミリーを設定画面で変更できるようにしました。

以下のバグを修正しました。

2. ルビで、対象となる漢字に以下の３文字が入る場合に正しくルビが振られないバグを修正しました。

- \u3005 々  // 同上記号・同の字点
- \u3006 〆  // 締め
- \u3007 〇  // 漢数字のゼロ

よろしくご検討くださいませ。