### PR TITLE
Fix `license` in package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Taiyo Fujii
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "activationEvents": [
     "*"
   ],
-  "copyright": "MIT",
   "contributes": {
     "commands": [
       {
@@ -109,5 +108,5 @@
     "test": "test"
   },
   "author": "",
-  "license": "ISC"
+  "license": "MIT"
 }


### PR DESCRIPTION
readme.mdを読む限りではMITライセンスのようだったので、おそらくpackage.jsonの方の記述が間違いなのでは…と思い修正してみました。

また、わかりやすいようにLICENSEファイルを追加しています（作者名の表記は https://github.com/ttrace/ のものを使わせていただきました）。このファイルがリポジトリにあると、GitHubではAboutのところにライセンスが表示されて便利なのでした（下図参照）。

<img width="326" alt="license" src="https://user-images.githubusercontent.com/10401/118532616-20de4080-b782-11eb-87aa-27b88e8c7f52.png">
