### PR TITLE
Define FontSize type as Template Literal Types

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,19 +102,40 @@ function sendsettingwebsockets(socketserver: any){
     }); 
 }
 
+type UnitOfFontSize = 'pt' | 'mm' | 'em' | 'rem' | 'px';
+type FontSize = `${number}${UnitOfFontSize}`;
+
+function parseFontSizeNum(fontSize: FontSize, defaultValue: number) : number {
+    const result = /(\d+)(\D+)/.exec(fontSize);
+    if (result && result[0]) {
+        return parseInt(result[0]);
+    } else {
+        return defaultValue;
+    }
+}
+
+function parseUnitOfFontSize(fontSize: FontSize, defaultValue: UnitOfFontSize) : UnitOfFontSize {
+    const result = /(\d+)(pt|mm|em|rem|px)/.exec(fontSize);
+    if (result && result[1]) {
+        return result[1] as UnitOfFontSize;
+    } else {
+        return defaultValue;
+    }
+}
+
 function getConfig(){
     const config = vscode.workspace.getConfiguration('Novel');
 
     const lineheightrate = 1.75;
-    const fontfamily        = config.get('preview.font-family');
-    const fontsize: string  = config.get('preview.fontsize')!;
-    const numfontsize       = parseInt(/(\d+)(\D+)/.exec(fontsize)![1]);
-    const unitoffontsize    = /(\d+)(\D+)/.exec(fontsize)![2];
-    const linelength:number = config.get('preview.linelength')!;
-    const linesperpage: number = config.get('preview.linesperpage')!;
-    const pagewidth         = (linesperpage * numfontsize * lineheightrate * 1.003) + unitoffontsize;
-    const pageheight        = (linelength * numfontsize) + unitoffontsize;
-    const lineheight        = (numfontsize * lineheightrate) + unitoffontsize;
+    const fontfamily        = config.get<string>('preview.font-family', 'serif');
+    const fontsize = config.get<FontSize>('preview.fontsize', '14pt' as FontSize);
+    const numfontsize       = parseFontSizeNum(fontsize, 14);
+    const unitoffontsize    = parseUnitOfFontSize(fontsize, 'pt');
+    const linelength = config.get<number>('preview.linelength', 40);
+    const linesperpage = config.get<number>('preview.linesperpage', 10);
+    const pagewidth         = `${linesperpage * numfontsize * lineheightrate * 1.003}${unitoffontsize}`;
+    const pageheight        = `${linelength * numfontsize}${unitoffontsize}`;
+    const lineheight        = `${numfontsize * lineheightrate}${unitoffontsize}`;
     
     const previewsettings = {
         lineheightrate,


### PR DESCRIPTION
`getConfig()`関数の定義中で、eslintによる警告が出ていたところについて、主に型の扱いを修正してみました。

まず`config.get<string>('preview.font-family', 'serif');`のように、`config.get()`の第2引数として値がなかった場合のデフォルト値を追加しています。また戻り値の型もジェネリクスを使って指定しています。これで型安全なスタイルになっているかと思います。

加えて、TypeScript特有の[Template Literal Types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html)を使って、フォントサイズの「型」である`FontSize`を定義しています。
この`FontSize`型から数値と単位を取り出す関数を`parseFontSizeNum()`と`parseUnitOfFontSize()`を定義して、こちらも型安全にしてみたつもりです（実はTemplate Literal Typesを実用用途で使ってみるのは初めてなので、変なことが起きてたらすみません…）
なお単位の方の`UnitOfFontSize`型はリテラル型とUnionを使って定義しています。

ついでに `pagewidth`等の算出についても、テンプレート文字列を使って数値と単位の文字列を連結するようにしてみました。

デフォルト値として与えている値はpackage.jsonで定義されているものを使ってみたつもりです。
本当はビルド時にpackage.jsonを読み込んでその値を使うようにできればよかったのですが、よく分からなかったので値をコピーしています。