### PR TITLE
`userregex` should be an array of tuple

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,9 +297,7 @@ function markUpHtml( myhtml: string ){
     let taggedHTML = myhtml;
     //configuration 読み込み
     const config = vscode.workspace.getConfiguration('Novel');
-    let userregex = new Array(0);
-        userregex = config.get('preview.userregex')!;
-//    console.log(userregex, userregex.length);
+    const userregex = config.get<Array<[string, string]>>('preview.userregex', []);
     if (userregex.length > 0){
         
         userregex.forEach( function(element){


### PR DESCRIPTION
`userregex`についての警告の修正です。
最初に配列を代入しているところは、次の瞬間上書きされるので消してしまって良さそうです。その結果、`userregex`は1度しか代入されなくなるので、`const`にできるようになりました。

そして`userregex`の型ですが、これは「2つの文字列からなるタプル」の配列を期待しているようなので、getの型指定をそのようにしてみました。VS Codeの画面では`element`や`thisreplace`も適切に型付けされているようなので、多分これで合ってると思います。

なお、デフォルト値としては空の配列 `[]` を与えています。これは `userregex.length > 0` が偽になるため、デフォルト値が使われた場合は`taggedHTML`には影響を与えないようになります。