### PR TITLE
remove non-null assertion; do nothing when `activeTextEditor` is null

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,16 +161,19 @@ const publishWebsocketsDelay: any = {
         delete this.timeoutID;
     },
     presskey: function(s: any) {
-      //this.cancel();
-      if (!keyPressFlag){
-            const updateCounter = Math.ceil(vscode.window.activeTextEditor!.document.getText().length / 50);
-            //const self = this;
-            const socketServer = s;
-            //const timer = timer;
-            this.timeoutID = setTimeout(socketServer => {
-                this.publish(socketServer);
+        //this.cancel();
+        if (!keyPressFlag){
+            const currentEditor = vscode.window.activeTextEditor;
+            if (currentEditor) {
+                const updateCounter = Math.ceil(currentEditor.document.getText().length / 50);
+                //const self = this;
+                const socketServer = s;
+                //const timer = timer;
+                this.timeoutID = setTimeout(socketServer => {
+                    this.publish(socketServer);
                 }, updateCounter, socketServer);
                 keyPressFlag = true;
+            }
         }
     },
     cancel: function() {


### PR DESCRIPTION
起動直後に「縦書きプレビュー」や「プレビューサーバー起動」を実行しようとすると、たまにエラーになることがありました。

あれこれ試してみたところ、テキストにカーソルがない状態で実行しようとすると `vscode.window.activeTextEditor` がnullになり、`[error] TypeError: Cannot read property 'document' of undefined` というエラーが発生するようでした。

これは`activeTextEditor`の存在チェックを入れて、nullのときは無視して何もしないようにすると治るようです。