### PR TITLE
use vscode API instead of Node module

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,10 +201,9 @@ function exportpdf(): void {
                     output.appendLine(`stderr: ${stderr}`);
                     return
                 }
-                    output.appendLine(`stdout: ${stdout}`);
-                    output.appendLine('PDFの保存が終わりました');
-                }
-            )
+                output.appendLine(`stdout: ${stdout}`);
+                output.appendLine('PDFの保存が終わりました');
+            })
             output.appendLine('HTMLの書き込みが完了しました');
         });
     }


### PR DESCRIPTION
* use `vscode.workspace.fs` API
* pathes are `vscode.Uri`, not `string`
* use `child_process.execFile` instead of `child_process.exec`

----

#18 についての修正で、extension.tsを置き換えてみました。
PDFが生成できることまでは確認できました。
また、パスのエスケープが大変そうだったので、vivliostyleのコマンド実行のところを`execFile`を使うように修正しています。