### PR TITLE
:bug: fix windows server path issue

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,7 +98,7 @@ function launchserver(originEditor: OriginEditor){
         }
     
         const uri = request.url;
-        let filename = path.join(documentRoot.path, uri!);
+        let filename = path.join(documentRoot.fsPath, uri!);
     
         fs.stat(filename, (err, stats) => {
 


### PR DESCRIPTION
Windows 10上でプレビューサーバーが404となっていました。
調べてみると、サーバーが次のようなパスを探してエラーとなっていました。
`'C:\c:\Users\o.itsuki\.vscode\extensions\taiyofujii.novel-writer-0.9.1\htdocs'`
Windows特有の先頭の`C:\`がうまく取り扱えていないことがわかります。
原因は`documentRoot.path`が次のように先頭に`/`が付いている形式になっていることでした。
`/c:/Users/o.itsuki/.vscode/extensions/taiyofujii.novel-writer-0.9.1/htdocs`
ここで、代わりに`documentRoot.fsPath`を使うと、fs用のパスになるようで次のようになります。
`c:\Users\o.itsuki\.vscode\extensions\taiyofujii.novel-writer-0.9.1\htdocs\`
これを利用することで、正しいWindowsのパスがサーバーに渡されてプレビューが正しく表示されるようになりました。

私はWindows機しか持っていないのでWindow上でしかテストをしていないため、他のプラットフォームで正しく動作することを確認してからマージしてもらえると助かります。