### PR TITLE
Unify all settings of this extension with NovelSettings

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,14 +1,15 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { getConfig } from './config';
 
 //fsモジュールの使い方 https://qiita.com/oblivion/items/2725a4b3ca3a99f8d1a3
 export default function compileDocs(): void
 {
     const   projectName             = vscode.workspace.workspaceFolders![0].name;
     const   projectPath: string     = vscode.workspace.workspaceFolders![0].uri.fsPath;
-    const   config                  = vscode.workspace.getConfiguration('Novel');
-    const   separatorString         = "\n\n　　　" + config.get<string>('compile.separator', '＊') +"\n\n";
+    const   config                  = getConfig();
+    const   separatorString         = "\n\n　　　" + config.separator +"\n\n";
     const   draftRootPath           = draftRoot();
 
     console.log('ProjectName: ',projectName);

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 export type UnitOfFontSize = 'pt' | 'mm' | 'em' | 'rem' | 'px' | 'vh' | 'vw' | 'q';
 export type FontSize = `${number}${UnitOfFontSize}`;
 
-export type PreviewSettings = {
+export type NovelSettings = {
     lineHeightRate: number,
     fontFamily: string,
     fontSize: FontSize,
@@ -14,6 +14,8 @@ export type PreviewSettings = {
     pageWidth: string,
     pageHeight: string,
     lineHeight: string,
+    userRegex: Array<[string, string]>,
+    separator: string
 };
 
 function parseFontSizeNum(fontSize: FontSize, defaultValue: number) : number {
@@ -34,7 +36,7 @@ function parseUnitOfFontSize(fontSize: FontSize, defaultValue: UnitOfFontSize) :
     }
 }
 
-export function getConfig() : PreviewSettings {
+export function getConfig() : NovelSettings {
     const config = vscode.workspace.getConfiguration('Novel');
 
     const lineHeightRate    = 1.75;
@@ -47,8 +49,10 @@ export function getConfig() : PreviewSettings {
     const pageWidth         = `${linesPerPage * numFontSize * lineHeightRate * 1.003}${unitOfFontSize}`;
     const pageHeight        = `${lineLength * numFontSize}${unitOfFontSize}`;
     const lineHeight        = `${numFontSize * lineHeightRate}${unitOfFontSize}`;
+    const userRegex         = config.get<Array<[string, string]>>('preview.userregex', []);
+    const separator         = config.get<string>('compile.separator', '＊');
 
-    const previewSettings = {
+    const novelSettings = {
         lineHeightRate,
         fontFamily    ,
         fontSize      ,
@@ -59,7 +63,9 @@ export function getConfig() : PreviewSettings {
         pageWidth     ,
         pageHeight    ,
         lineHeight    ,
+        userRegex     ,
+        separator
     }
-    return previewSettings;
+    return novelSettings;
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { getConfig } from './config';
 
 export type OriginEditor = vscode.TextEditor | "active" | undefined;
 
@@ -38,8 +39,8 @@ export function editorText(originEditor: OriginEditor) : string {
 export function markUpHtml( myHtml: string ){
     let taggedHTML = myHtml;
     //configuration 読み込み
-    const config = vscode.workspace.getConfiguration('Novel');
-    const userRegex = config.get<Array<[string, string]>>('preview.userregex', []);
+    const config = getConfig();
+    const userRegex = config.userRegex;
     if (userRegex.length > 0){
         userRegex.forEach( function(element){
                 const thisMatch = new RegExp(element[0], 'gi');


### PR DESCRIPTION
`PreviewSettings`ですが、`userRegex`と`separator`を追加した`NovelSettings`という型に変更してみました。`NovelSettings`は、この拡張内で利用する設定全体をまとめたものになります。

こうすると、設定の詳細は`src/config.ts`内に集約させることになり、`src/config.ts`以外のコードの中では`vscode.workspace.getConfiguration`を使わずに`config = getConfig()`だけで設定の値を取り出せるようになるのと、configから値を取り出す際にも`<Array<[string, string]>>`等の型を個別に指定しないで済むようになります。