### PR TITLE
不正なCSSプロパティ名を修正

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -517,7 +517,7 @@ function getWebviewContent() {
   
       p {
         font-size: calc(110mm / ${previewSettings.lineLength});
-        line height: 1.65;
+        line-height: 1.65;
         text-indent: 0em;
         hanging-punctuation: force-end;
         line-break:strict;


### PR DESCRIPTION
`line-height`が`line height`となっている箇所があったので修正いたしました。
この修正で`p`タグに`line-height`が適用されるため、ビルドされたPDFの行間が変更されます。