### PR TITLE
Set "ambiguousCharacters" to false by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
         "path": "./syntaxes/novel.tmGrammar.json"
       }
     ],
+    "configurationDefaults": {
+      "[novel]": {
+        "editor.unicodeHighlight.ambiguousCharacters": false
+      }
+    },
     "configuration": {
       "title": "縦書きプレビュー設定",
       "properties": {


### PR DESCRIPTION
はじめまして、以前ツイートしていらっしゃった[Unicode Highlights Ambiguous Charactersを拡張機能からオフにする件]、VS CodeビルトインのMarkdown拡張機能のソースファイルを眺めていて見つけたのですが、`package.json`に書ける`contributes.configurationDefaults`で既定値を上書きできるようです。

[Unicode Highlights Ambiguous Charactersを拡張機能からオフにする件]: https://twitter.com/t_trace/status/1476173774945132549

参考ソースファイル:

- https://github.com/microsoft/vscode/blob/a853936292178200eb58c2a9904d7a7dcf98cce8/extensions/markdown-basics/package.json#L91-L96

参考ドキュメンテーション:

- https://code.visualstudio.com/api/references/contribution-points#contributes.configurationDefaults

既にご存じでしたら恐縮ですが、PRも作ってみましたのでよろしければお試しください。