### PR TITLE
Fix websocket message handling

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,8 +132,8 @@ function launchserver(originEditor: OriginEditor){
         
         s.on("connection", ws => {
             //console.log(previewvariables());
-            ws.on("message", (messageAsString) => {
-                const message = JSON.stringify(messageAsString);
+            ws.on("message", (data, isBinary) => {
+                const message = isBinary ? data : data.toString();
         
                 console.log("Received: " + message);
 


### PR DESCRIPTION
ws 8.0.0~ の message イベントに関する [breaking change](https://github.com/websockets/ws/releases/tag/8.0.0) によって縦書きプレビューが正しく動作しない問題を修正しています。