### PR TITLE
プレビューが動かないことがあるのを修正する

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,14 +261,15 @@ function emptyPort(callback: any) {
     const server = new net.Server();
 
     socket.on('error', function (e) {
-        try {
-            console.log('try:', port);
-            server.listen(port, '127.0.0.1');
+        console.log('try:', port);
+        server.on('listening', () => {
             server.close();
+            console.log('ok:', port);
             callback(port);
-        } catch (e) {
+        }).on('error', () => {
+            console.log('ng:', port);
             loop();
-        }
+        }).listen(port, '127.0.0.1');
     });
 
     function loop() {


### PR DESCRIPTION
- プレビューサーバを立ち上げてもリクエストに応答しない場合がある（Windowsでは起こらないがLinuxでは100%起こる）
- emptyPortでnet.Serverの使い方が正しくないのが原因
  - 非同期APIなのでlisteningイベントを受け取ってからcloseする必要があり、元のコードのままではタイミングによってcloseされずにポートを握りっぱなしになる
  - エラーはerrorイベントで通知されるので、try-catchではなくon('error',...)で受け取る必要がある
