### PR TITLE
Fix comment-out parsing and scope definitions

### DIFF
--- a/syntaxes/novel.tmGrammar.json
+++ b/syntaxes/novel.tmGrammar.json
@@ -4,17 +4,17 @@
   "repository": {
     "expression": {
       "patterns": [
-        { "include": "#rubymother" },
-        { "include": "#aozora-motherword" },
-        { "include": "#original-word" },
-        { "include": "#numbers" },
-        { "include": "#units" },
+        { "include": "#rubymother"},
+        { "include": "#aozora-motherword"},
+        { "include": "#original-word"},
+        { "include": "#numbers"},
+        { "include": "#units"},
         { "include": "#aozora-expression" },
-        { "include": "#ruby-expression" },
-        { "include": "#parenthesis-expression" },
-        { "include": "#cornerfilledparenthesis-expression" },
-        { "include": "#cornerparenthesis-expression" },
-        { "include": "#japanesequote-expression" },
+        { "include": "#ruby-expression"},
+        { "include": "#parenthesis-expression"},
+        { "include": "#cornerfilledparenthesis-expression"},
+        { "include": "#cornerparenthesis-expression"},
+        { "include": "#japanesequote-expression"},
         { "include": "#dialogue-expression" },
         { "include": "#comment-out" }
       ]
@@ -36,10 +36,10 @@
       "name": "constant.numeric"
     },
     "units": {
-      "match": "(?<=[一二三四五六七八九十〇]+|[0-9]+|[０-９]+)([一-龠]+|[ァ-ー]+)",
+      "match":"(?<=[一二三四五六七八九十〇]+|[0-9]+|[０-９]+)([一-龠]+|[ァ-ー]+)",
       "name": "variable.parameter"
     },
-    "aozora-expression": {
+    "aozora-expression":{
       "begin": "［",
       "end": "］",
       "beginCaptures": {
@@ -49,7 +49,9 @@
         "0": { "name": "string.quoted" }
       },
       "name": "keyword",
-      "patterns": [{ "include": "#aozora-parameter" }]
+      "patterns": [
+        { "include": "#aozora-parameter" }
+      ]
     },
     "aozora-parameter": {
       "begin": "「",
@@ -62,7 +64,7 @@
       },
       "name": "keyword"
     },
-    "parenthesis-expression": {
+    "parenthesis-expression":{
       "begin": "（",
       "end": "）",
       "beginCaptures": {
@@ -73,7 +75,7 @@
       },
       "name": "keyword"
     },
-    "cornerfilledparenthesis-expression": {
+    "cornerfilledparenthesis-expression":{
       "begin": "【",
       "end": "】",
       "beginCaptures": {
@@ -84,7 +86,7 @@
       },
       "name": "keyword"
     },
-    "cornerparenthesis-expression": {
+    "cornerparenthesis-expression":{
       "begin": "［",
       "end": "］",
       "beginCaptures": {
@@ -95,7 +97,7 @@
       },
       "name": "keyword"
     },
-    "japanesequote-expression": {
+    "japanesequote-expression":{
       "begin": "〝",
       "end": "〟",
       "beginCaptures": {
@@ -106,7 +108,7 @@
       },
       "name": "keyword"
     },
-    "ruby-expression": {
+    "ruby-expression":{
       "begin": "《",
       "end": "》",
       "beginCaptures": {
@@ -128,22 +130,22 @@
       },
       "name": "string.quoted",
       "patterns": [
-        { "include": "#parenthesis-expression" },
-        { "include": "#cornerfilledparenthesis-expression" },
-        { "include": "#cornerparenthesis-expression" },
-        { "include": "#japanesequote-expression" },
+        { "include": "#parenthesis-expression"},
+        { "include": "#cornerfilledparenthesis-expression"},
+        { "include": "#cornerparenthesis-expression"},
+        { "include": "#japanesequote-expression"},
         { "include": "#aozora-expression" },
         { "include": "#aozora-parameter" },
-        { "include": "#ruby-expression" },
-        { "include": "#rubymother" },
-        { "include": "#original-word" },
-        { "include": "#numbers" },
-        { "include": "#units" },
-        { "include": "#dialogue-inline" },
-        { "include": "#parens" }
+        { "include": "#ruby-expression"},
+        { "include": "#rubymother"},
+        { "include": "#original-word"},
+        { "include": "#numbers"},
+        { "include": "#units"},
+        { "include": "#dialogue-inline"},
+        { "include": "#parens"}
       ]
     },
-    "comment-out": {
+    "comment-out":{
       "begin": "<!--\\s*",
       "end": "\\s*-->",
       "beginCaptures": {

--- a/syntaxes/novel.tmGrammar.json
+++ b/syntaxes/novel.tmGrammar.json
@@ -4,17 +4,17 @@
   "repository": {
     "expression": {
       "patterns": [
-        { "include": "#rubymother"},
-        { "include": "#aozora-motherword"},
-        { "include": "#original-word"},
-        { "include": "#numbers"},
-        { "include": "#units"},
+        { "include": "#rubymother" },
+        { "include": "#aozora-motherword" },
+        { "include": "#original-word" },
+        { "include": "#numbers" },
+        { "include": "#units" },
         { "include": "#aozora-expression" },
-        { "include": "#ruby-expression"},
-        { "include": "#parenthesis-expression"},
-        { "include": "#cornerfilledparenthesis-expression"},
-        { "include": "#cornerparenthesis-expression"},
-        { "include": "#japanesequote-expression"},
+        { "include": "#ruby-expression" },
+        { "include": "#parenthesis-expression" },
+        { "include": "#cornerfilledparenthesis-expression" },
+        { "include": "#cornerparenthesis-expression" },
+        { "include": "#japanesequote-expression" },
         { "include": "#dialogue-expression" },
         { "include": "#comment-out" }
       ]
@@ -36,10 +36,10 @@
       "name": "constant.numeric"
     },
     "units": {
-      "match":"(?<=[一二三四五六七八九十〇]+|[0-9]+|[０-９]+)([一-龠]+|[ァ-ー]+)",
+      "match": "(?<=[一二三四五六七八九十〇]+|[0-9]+|[０-９]+)([一-龠]+|[ァ-ー]+)",
       "name": "variable.parameter"
     },
-    "aozora-expression":{
+    "aozora-expression": {
       "begin": "［",
       "end": "］",
       "beginCaptures": {
@@ -49,9 +49,7 @@
         "0": { "name": "string.quoted" }
       },
       "name": "keyword",
-      "patterns": [
-        { "include": "#aozora-parameter" }
-      ]
+      "patterns": [{ "include": "#aozora-parameter" }]
     },
     "aozora-parameter": {
       "begin": "「",
@@ -64,7 +62,7 @@
       },
       "name": "keyword"
     },
-    "parenthesis-expression":{
+    "parenthesis-expression": {
       "begin": "（",
       "end": "）",
       "beginCaptures": {
@@ -75,7 +73,7 @@
       },
       "name": "keyword"
     },
-    "cornerfilledparenthesis-expression":{
+    "cornerfilledparenthesis-expression": {
       "begin": "【",
       "end": "】",
       "beginCaptures": {
@@ -86,7 +84,7 @@
       },
       "name": "keyword"
     },
-    "cornerparenthesis-expression":{
+    "cornerparenthesis-expression": {
       "begin": "［",
       "end": "］",
       "beginCaptures": {
@@ -97,7 +95,7 @@
       },
       "name": "keyword"
     },
-    "japanesequote-expression":{
+    "japanesequote-expression": {
       "begin": "〝",
       "end": "〟",
       "beginCaptures": {
@@ -108,7 +106,7 @@
       },
       "name": "keyword"
     },
-    "ruby-expression":{
+    "ruby-expression": {
       "begin": "《",
       "end": "》",
       "beginCaptures": {
@@ -128,33 +126,33 @@
       "endCaptures": {
         "0": { "name": "string.quoted" }
       },
-      "name": "comment.block ",
+      "name": "string.quoted",
       "patterns": [
-        { "include": "#parenthesis-expression"},
-        { "include": "#cornerfilledparenthesis-expression"},
-        { "include": "#cornerparenthesis-expression"},
-        { "include": "#japanesequote-expression"},
+        { "include": "#parenthesis-expression" },
+        { "include": "#cornerfilledparenthesis-expression" },
+        { "include": "#cornerparenthesis-expression" },
+        { "include": "#japanesequote-expression" },
         { "include": "#aozora-expression" },
         { "include": "#aozora-parameter" },
-        { "include": "#ruby-expression"},
-        { "include": "#rubymother"},
-        { "include": "#original-word"},
-        { "include": "#numbers"},
-        { "include": "#units"},
-        { "include": "#dialogue-inline"},
-        { "include": "#parens"}
+        { "include": "#ruby-expression" },
+        { "include": "#rubymother" },
+        { "include": "#original-word" },
+        { "include": "#numbers" },
+        { "include": "#units" },
+        { "include": "#dialogue-inline" },
+        { "include": "#parens" }
       ]
     },
-    "comment-out":{
-      "begin": "<!--  ",
-      "end": "  -->",
+    "comment-out": {
+      "begin": "<!--\\s*",
+      "end": "\\s*-->",
       "beginCaptures": {
-        "0": { "name": "string.quoted" }
+        "0": { "name": "comment.block" }
       },
       "endCaptures": {
-        "0": { "name": "string.quoted" }
+        "0": { "name": "comment.block" }
       },
-      "name": "entity"
+      "name": "comment.block"
     }
   }
 }


### PR DESCRIPTION
This PR fixes issues with HTML-style comment parsing and improves scope definitions.

### Changes
- Allow flexible whitespace in comment delimiters (`<!--` and `-->`) using `\s*`
- Change comment scope from `entity` to `comment.block`
- Fix incorrect scopes in `beginCaptures` / `endCaptures`
- Correct dialogue scope from `comment.block` to `string.quoted`

### Result
- Comments are now properly highlighted
- Users can customize comment colors via VSCode themes
- Behavior is more consistent with standard TextMate scopes

No breaking changes.

This also resolves the issue where comments were not highlighted unless two spaces were present.

---

HTML形式のコメント（&lt;!-- --&gt;）が正しくハイライトされない問題を修正しました。
また、scope定義を整理し、VSCode標準の挙動に合わせています。