### PR TITLE
原稿を結合する際の区切り文字列を復帰する

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,10 +203,15 @@
           "default": false,
           "description": "原稿ツリーでファイルの並び替えを行うかどうかを設定します\n有効にすると原稿ツリーでファイル・フォルダーの順番を入れ替えられますが、ファイル・フォルダーの名前の先頭に連番を付与します\nファイル名を書き換える機能なので、ワークスペースごとに設定することを推奨します"
         },
+        "Novel.compile.enableSeparator": {
+          "type": "boolean",
+          "default": false,
+          "description": "原稿を結合する際に区切り文字列を挿入するかどうかを指定してください"
+        },
         "Novel.compile.separator": {
           "type": "string",
           "default": "＊",
-          "description": "原稿を結合する際の区切り文字列を指定してください"
+          "description": "原稿を結合する際の区切り文字を指定してください\nこのオプションを有効にするには、区切り文字列を挿入することを有効にしてください"
         },
         "Novel.general.filetype": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -203,6 +203,11 @@
           "default": false,
           "description": "原稿ツリーでファイルの並び替えを行うかどうかを設定します\n有効にすると原稿ツリーでファイル・フォルダーの順番を入れ替えられますが、ファイル・フォルダーの名前の先頭に連番を付与します\nファイル名を書き換える機能なので、ワークスペースごとに設定することを推奨します"
         },
+        "Novel.compile.separator": {
+          "type": "string",
+          "default": "＊",
+          "description": "原稿を結合する際の区切り文字列を指定してください"
+        },
         "Novel.general.filetype": {
           "type": "string",
           "default": ".txt",

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -16,7 +16,7 @@ export default function compileDocs(): void {
         path.basename(deadLineFolderPath());
   const projectPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
   const config = getConfig();
-  const separatorString = "\n　　　" + config.separator + "\n\n";
+  const separatorString = config.enableSeparator ? "\n　　　" + config.separator + "\n\n" : "";
   const draftRootPath =
     deadLineFolderPath() == "" ? draftRoot() : deadLineFolderPath();
 

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -16,7 +16,7 @@ export default function compileDocs(): void {
         path.basename(deadLineFolderPath());
   const projectPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
   const config = getConfig();
-  const separatorString = "\n\n　　　" + config.separator + "\n\n";
+  const separatorString = "\n　　　" + config.separator + "\n\n";
   const draftRootPath =
     deadLineFolderPath() == "" ? draftRoot() : deadLineFolderPath();
 
@@ -41,13 +41,22 @@ export default function compileDocs(): void {
 
   //  テキストを書き込む
   const filelist = fileList(draftRootPath).files;
-  filelist.forEach((listItem: { dir?: string; depthIndicator?: number }) => {
-    let appendingContext = "";
+  let separatorStart: string | null = null;
+  filelist.forEach((listItem: { dir?: string }) => {
+    let appendingContext = typeof separatorStart === "string" ? separatorStart + separatorString : "";
+
     if (listItem.dir) {
-      appendingContext = fs.readFileSync(listItem.dir, "utf8");
-    } else if (listItem.depthIndicator) {
-      appendingContext = separatorString;
+      appendingContext += fs.readFileSync(listItem.dir, "utf8");
+
+      if (appendingContext.endsWith("\n")) {
+        separatorStart = "";
+      } else {
+        // 改行で終わっていない場合は、次のテキストとの間に改行を入れる
+        // すなわち`\n\n separator\n\n`の形にする
+        separatorStart = "\n";
+      }
     }
+    
     fs.appendFileSync(compiledTextFilePath, appendingContext);
   });
   //console.log(fileList(draftRootPath, 0).files);
@@ -86,6 +95,7 @@ type File = {
   length?: number;
   directoryName?: string;
   directoryLength?: number;
+  // FIXME: 一度も使われていないプロパティです。必要なければ削除してください。
   depthIndicator?: number;
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export type NovelSettings = {
   numberFormatR: string;
   numberFormatL: string;
   userRegex: Array<[string, string]>;
+  enableSeparator: boolean;
   separator: string;
   vscodeTheme: vscode.ColorTheme;
   sceneNav: boolean;
@@ -53,6 +54,7 @@ export function getConfig(): NovelSettings {
     "preview.userRegex",
     []
   );
+  const enableSeparator = config.get<boolean>("compile.enableSeparator", false);
   const separator = config.get<string>("compile.separator", "＊");
   const vscodeTheme = vscode.window.activeColorTheme;
   const sceneNav = config.get<boolean>("editor.sceneNavigator", true);
@@ -89,6 +91,7 @@ export function getConfig(): NovelSettings {
     numberFormatR,
     numberFormatL,
     userRegex,
+    enableSeparator,
     separator,
     vscodeTheme,
     sceneNav,


### PR DESCRIPTION
#77 の対応内容です。

- `Novel.compile.separator`を再導入します
- 原稿を結合する際、前のファイルの最終改行に基づいて、区切り文字列を１つまたは２つの改行と判断します
   - 前ファイルの末尾に改行がある場合：区切りとして改行１つを使用
   - 改行がない場合：改行を補完し、結果的に改行2つ分の区切りとする
- 区切り文字列を不要とするユーザー向けに、`Novel.compile.enableSeparator`の設定を追加しています
   - 不要なケースがあるため
   - オフにしても、前のファイルの末尾に改行がない場合は自動的に改行されます

## テストと結果

<img width="937" height="314" alt="image" src="https://github.com/user-attachments/assets/dea74ee3-6328-4678-9469-669aeab9e9de" />

<img width="305" height="122" alt="image" src="https://github.com/user-attachments/assets/7590f040-a94e-4ef4-a1e1-30452df3cc93" />
